### PR TITLE
refact: make custom config also defined within env blocks.

### DIFF
--- a/assets/filebeat/filebeat.tpl
+++ b/assets/filebeat/filebeat.tpl
@@ -12,9 +12,6 @@
   json.keys_under_root: true
   {{end}}
   fields:
-      {{range $key, $value := .CustomFields}}
-      {{ $key }}: {{ $value }}
-      {{end}}
       {{range $key, $value := .Tags}}
       {{ $key }}: {{ $value }}
       {{end}}

--- a/docs/filebeat/docs.md
+++ b/docs/filebeat/docs.md
@@ -125,7 +125,8 @@ There are many labels you can use to describe the log info.
 - `aliyun.logs.$name=$path`
     - Name is an identify, can be any string you want. The valid characters in name are `0-9a-zA-Z_-`
     - Path is the log file path, can contains wildcard. `stdout` is a special value which means stdout of the container.
-- `aliyun.logs.$name.tags="k1=v1,k2=v2"`: tags will be appended to log. 
+- `aliyun.logs.$name.tags="k1=v1,k2=v2"`: tags will be appended to log.
+- `aliyun.logs.$name.configs="k1=v1,k2=v2"`: customized configs for filebeat, it will be part of the filebeat configs which corresponding the container.
 - `aliyun.logs.$name.target=target-for-log-storage`: target is used by the output plugins, instruct the plugins to store
 logs in appropriate place. For elasticsearch output, target means the log index in elasticsearch. For aliyun_sls output,
 target means the logstore in aliyun sls. The default value of target is the log name.

--- a/pilot/filebeat_piloter.go
+++ b/pilot/filebeat_piloter.go
@@ -3,9 +3,6 @@ package pilot
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
-	"github.com/elastic/go-ucfg"
-	"github.com/elastic/go-ucfg/yaml"
 	"io/ioutil"
 	"os"
 	"os/exec"
@@ -13,6 +10,10 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/yaml"
 )
 
 // Global variables for FilebeatPiloter

--- a/pilot/pilot_test.go
+++ b/pilot/pilot_test.go
@@ -1,11 +1,12 @@
 package pilot
 
 import (
+	"os"
+	"testing"
+
 	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/api/types"
 	"gopkg.in/check.v1"
-	"os"
-	"testing"
 )
 
 func Test(t *testing.T) {
@@ -32,6 +33,7 @@ func (p *PilotSuite) TestGetLogConfigs(c *check.C) {
 		"aliyun.logs.hello":                    "/var/log/hello.log",
 		"aliyun.logs.hello.format":             "json",
 		"aliyun.logs.hello.tags":               "name=hello,stage=test",
+		"aliyun.logs.hello.configs":            "multiline.pattern='^\\[',multiline.negate=true,multiline.match=after",
 		"aliyun.logs.hello.format.time_format": "%Y-%m-%d",
 	}
 
@@ -52,6 +54,7 @@ func (p *PilotSuite) TestGetLogConfigs(c *check.C) {
 	c.Assert(configs[0].ContainerDir, check.Equals, "/var/log")
 	c.Assert(configs[0].File, check.Equals, "hello.log")
 	c.Assert(configs[0].Tags, check.HasLen, 4)
+	c.Assert(configs[0].CustomConfigs, check.HasLen, 3)
 	c.Assert(configs[0].FormatConfig, check.HasLen, 2)
 
 	//Test regex format
@@ -59,6 +62,7 @@ func (p *PilotSuite) TestGetLogConfigs(c *check.C) {
 		"aliyun.logs.hello":                "/var/log/hello.log",
 		"aliyun.logs.hello.format":         "regexp",
 		"aliyun.logs.hello.tags":           "name=hello,stage=test",
+		"aliyun.logs.hello.configs":        "multiline.pattern='^\\[',multiline.negate=true,multiline.match=after",
 		"aliyun.logs.hello.format.pattern": "(?=name:hello).*",
 	}
 	configs, err = pilot.getLogConfigs("/path/to/json.log", mounts, labels)

--- a/pilot/piloter.go
+++ b/pilot/piloter.go
@@ -3,7 +3,6 @@ package pilot
 import (
 	"fmt"
 	"os"
-	"strings"
 )
 
 // Global variables for piloter
@@ -38,25 +37,4 @@ func NewPiloter(baseDir string) (Piloter, error) {
 		return NewFluentdPiloter()
 	}
 	return nil, fmt.Errorf("InvalidPilotType")
-}
-
-// CustomConfig custom config
-func CustomConfig(name string, customConfigs map[string]string, logConfig *LogConfig) {
-	if os.Getenv(ENV_PILOT_TYPE) == PILOT_FILEBEAT {
-		fields := make(map[string]string)
-		configs := make(map[string]string)
-		for k, v := range customConfigs {
-			if strings.HasPrefix(k, name) {
-				key := strings.TrimPrefix(k, name+".")
-				if strings.HasPrefix(key, "fields") {
-					key2 := strings.TrimPrefix(key, "fields.")
-					fields[key2] = v
-				} else {
-					configs[key] = v
-				}
-			}
-		}
-		logConfig.CustomFields = fields
-		logConfig.CustomConfigs = configs
-	}
 }


### PR DESCRIPTION
This is a fork version of log-pilot, and I'm going to add an alternative way to implement custom config, the more features we indeed need is also coming soon.
